### PR TITLE
Licenses profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
           <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
       </distributionManagement>
-      
+
       <properties>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
       </properties>
@@ -351,6 +351,126 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>licenses</id>
+      <properties>
+        <openshiftio.dir>${project.basedir}/.openshiftio</openshiftio.dir>
+        <licenses.dir>${project.basedir}/src/licenses</licenses.dir>
+
+        <license-maven-plugin.version>1.13</license-maven-plugin.version>
+        <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>${licenses.dir}</directory>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>${license-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>generate-initial-licenses</id>
+                <goals>
+                  <goal>download-licenses</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <licensesOutputFile>${project.build.directory}/licenses.xml</licensesOutputFile>
+                  <offline>true</offline>
+                </configuration>
+              </execution>
+              <execution>
+                <id>download-licenses</id>
+                <goals>
+                  <goal>download-licenses</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <licensesConfigFile>${project.build.directory}/licenses.xml</licensesConfigFile>
+                  <licensesOutputFile>${licenses.dir}/licenses.xml</licensesOutputFile>
+                  <licensesOutputDirectory>${licenses.dir}/content</licensesOutputDirectory>
+                  <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>xml-maven-plugin</artifactId>
+            <version>${xml-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>fix-licenses</id>
+                <goals>
+                  <goal>transform</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <transformationSets>
+                    <transformationSet>
+                      <dir>${project.build.directory}</dir>
+                      <includes>
+                        <include>licenses.xml</include>
+                      </includes>
+                      <stylesheet>${openshiftio.dir}/licenses-fix.xsl</stylesheet>
+                      <outputDir>${project.build.directory}</outputDir>
+                      <fileMappers>
+                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                          <targetExtension>.xml</targetExtension>
+                        </fileMapper>
+                      </fileMappers>
+                    </transformationSet>
+                  </transformationSets>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-licenses-html</id>
+                <goals>
+                  <goal>transform</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <transformationSets>
+                    <transformationSet>
+                      <dir>${project.build.directory}</dir>
+                      <includes>
+                        <include>licenses.xml</include>
+                      </includes>
+                      <stylesheet>${openshiftio.dir}/licenses.xsl</stylesheet>
+                      <outputDir>${licenses.dir}</outputDir>
+                      <fileMappers>
+                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                          <targetExtension>.html</targetExtension>
+                        </fileMapper>
+                      </fileMappers>
+                      <parameters>
+                        <parameter>
+                          <name>product</name>
+                          <value>${project.name}</value>
+                        </parameter>
+                      </parameters>
+                    </transformationSet>
+                  </transformationSets>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
I've added clean plugin to delete licenses folder when profile is enabled, because local files do not get downloaded otherwise for some reason. I might be missing something, but so far haven't found another solution.
The workflow what happens:
1. Clean plugin deletes `licenses`
2. license-maven-plugin execution generate-initial-licenses generates initial licenses.xml in a target directory without downloading licenses.
3. xml-maven-plugin execution fix-licenses aligns names and URLs in target/licenses.xml
4. license-maven-plugin execution download-licenses copies target/licenses.xml to licenses/licenses.xml after fixing indentations and ordering as well as downloads licenses to licenses/content
5. xml-maven-plugin execution generate-licenses-html generates licenses/licenses.html based on target/licenses.xml in case order of 4 and 5 is not maintained.

Booster needs to have following two xls files in .openshiftio directory to get licenses generated: https://github.com/gytis/spring-boot-http-booster/tree/master-licenses-parent/.openshiftio.

It's quite archaic at the moment, but I'm sure we can improve it in the future. What are your thoughts?