### PR TITLE
Change licenses plugin goal to aggregate-download-licenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
               <execution>
                 <id>generate-initial-licenses</id>
                 <goals>
-                  <goal>download-licenses</goal>
+                  <goal>aggregate-download-licenses</goal>
                 </goals>
                 <phase>generate-resources</phase>
                 <configuration>
@@ -400,7 +400,7 @@
               <execution>
                 <id>download-licenses</id>
                 <goals>
-                  <goal>download-licenses</goal>
+                  <goal>aggregate-download-licenses</goal>
                 </goals>
                 <phase>process-resources</phase>
                 <configuration>


### PR DESCRIPTION
No changes as needed for single module projects.

In multi-module projects all the steps as in single module project are required plus the following profile in root pom.xml to stop inheritance of a license plugin: https://github.com/gytis/spring-boot-circuit-breaker-booster/blob/master/pom.xml#L85.

Here's an example of the generated licenses in Spring Boot circuit breaker booster: https://github.com/gytis/spring-boot-circuit-breaker-booster/tree/master/src/licenses