### PR TITLE
configure the fabric8 maven plugin to use the Red Hat base Java image by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
 
     <booster-common.version>2</booster-common.version>
+
+    <fabric8.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift</fabric8.generator.from>
   </properties>
 
   <scm>


### PR DESCRIPTION
Resolves https://github.com/openshiftio/appdev-planning/issues/36