### PR TITLE
Update fabric8 maven plugin version to display the build log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
 
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
-    <fabric8-maven-plugin.version>3.5.1</fabric8-maven-plugin.version>
+    <fabric8-maven-plugin.version>3.5.22</fabric8-maven-plugin.version>
     <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>


### PR DESCRIPTION
I've seen weird error messages with 3.5.1 locally (`[ERROR] F8: Failed to tail build log : java.io.IOException: Pipe not connected`) that don't happen with the latest version.

(Also FMP 3.5.1 fails spectacularly with OpenShift Origin 3.6.0, while FMP 3.5.22 somewhat works. Shows weird errors, but works.)